### PR TITLE
Restrict CI workflow to master branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,8 @@ name: CI
 
 on:
   push:
-    branches: ["**"]
+    branches: [master]
   pull_request:
-    branches: ["**"]
 
 jobs:
   # ── Go API ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Updated the CI workflow configuration to run only on the master branch instead of all branches, and removed the branch filter from pull request triggers.

## Key Changes
- Changed push trigger to only run on `master` branch instead of `["**"]` (all branches)
- Removed the `branches` filter from pull_request trigger to allow CI to run on all pull requests regardless of target branch

## Details
This change optimizes CI resource usage by preventing the workflow from running on every branch push, while still ensuring pull requests are validated before merging to master.

https://claude.ai/code/session_01P8g38cDp1hg2vDhSeYv5Y9