### PR TITLE
Add favicon and logo icon to navigation header

### DIFF
--- a/racemate-web/index.html
+++ b/racemate-web/index.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>RaceMate</title>
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="apple-touch-icon" href="/favicon.svg" />
   </head>
   <body>
     <div id="app"></div>

--- a/racemate-web/public/favicon.svg
+++ b/racemate-web/public/favicon.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Dark rounded background -->
+  <rect width="32" height="32" rx="7" fill="#111113"/>
+  <!-- Track corner boundaries -->
+  <path d="M6 26 L6 8 Q6 6 8 6 L26 6" stroke="#3a3a3e" stroke-width="3" fill="none" stroke-linecap="round"/>
+  <!-- Racing apex line -->
+  <path d="M6 26 Q20 26 26 20 Q30 16 26 6" stroke="#e8304a" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+</svg>

--- a/racemate-web/src/components/Nav.tsx
+++ b/racemate-web/src/components/Nav.tsx
@@ -6,7 +6,12 @@ export function Nav() {
 
   return (
     <header class="h-12 border-b border-[var(--border)] flex items-center px-5 gap-8">
-      <Link href="/" class="text-sm font-bold tracking-widest uppercase text-[var(--accent)]">
+      <Link href="/" class="flex items-center gap-2 text-sm font-bold tracking-widest uppercase text-[var(--accent)]">
+        <svg width="22" height="22" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <rect width="32" height="32" rx="7" fill="#1c1c1f"/>
+          <path d="M6 26 L6 8 Q6 6 8 6 L26 6" stroke="#3a3a3e" stroke-width="3" stroke-linecap="round"/>
+          <path d="M6 26 Q20 26 26 20 Q30 16 26 6" stroke="#e8304a" stroke-width="2.5" stroke-linecap="round"/>
+        </svg>
         RaceMate
       </Link>
       <nav class="flex gap-5 text-sm text-[var(--muted)]">


### PR DESCRIPTION
## Summary
This PR adds visual branding to the RaceMate application by introducing a favicon and displaying a logo icon in the navigation header.

## Key Changes
- **Added favicon.svg**: Created a new SVG favicon featuring a racing-themed design with a dark background, track boundary lines, and a red racing apex line
- **Updated Nav component**: Embedded the logo icon inline in the navigation header next to the "RaceMate" text, using flexbox layout for proper alignment
- **Updated index.html**: Added favicon link tags to the document head for both standard browsers and Apple devices

## Implementation Details
- The favicon uses a 32x32 SVG viewBox with a dark rounded background (#111113) and accent red stroke (#e8304a) to match the application's design system
- The navigation logo is a scaled-down version (22x22) of the favicon with a slightly lighter background (#1c1c1f) for better visibility in the header
- Both favicon and logo share the same visual design language (track corner boundaries and racing apex line) for consistent branding

https://claude.ai/code/session_01W2pFutfNQcS1CpbbySq3Qe