### PR TITLE
Add personal bests section and improve compare page linking

### DIFF
--- a/racemate-web/src/pages/Home.tsx
+++ b/racemate-web/src/pages/Home.tsx
@@ -328,7 +328,7 @@ export function Home() {
                         ) : (fastestLap && !isAlreadyFastest && (
                           <Link
                             href={`/compare?lap_a=${lap.id}&lap_b=${fastestLap.id}`}
-                            onClick={(e) => e.stopPropagation()}
+                            onClick={(e: MouseEvent) => e.stopPropagation()}
                             class="text-xs text-[var(--accent)] hover:opacity-80 transition-opacity whitespace-nowrap"
                           >
                             Compare →


### PR DESCRIPTION
## Summary
This PR adds a new "Personal Bests" section to the home page that displays the user's best lap times per track and car class combination, along with comparisons to the global fastest laps. It also improves the Compare page to support URL-based lap selection for direct linking.

## Key Changes

- **Personal Bests Section**: Added a new table on the home page showing:
  - User's best lap time for each track/car class combination
  - Global fastest lap time for comparison
  - Time gap between user's best and fastest lap
  - Visual indicators (green for fastest, red for slower)
  - Direct "Compare" links to compare user's best against the fastest lap

- **Compare Page URL Support**: 
  - Compare page now accepts `lap_a` and `lap_b` query parameters
  - Automatically loads comparison data when parameters are present in the URL
  - Enables direct linking to specific lap comparisons from other parts of the app

- **New Dependencies**:
  - Added `formatDelta` utility function import for displaying time gaps
  - Added `useAuth` hook to access current user information
  - Added `useSearch` hook from wouter for URL parameter parsing

## Implementation Details

- Personal bests are computed by grouping user's laps by track and car class, keeping only the best lap per combination
- Global fastest laps are fetched per track to find the fastest lap in each car class
- The gap calculation shows positive values when user is slower than the fastest lap
- Compare page initialization is deferred until URL parameters are available to avoid unnecessary API calls

https://claude.ai/code/session_01XLL6gqiU8xZefvsHxerbFw