### PR TITLE
Refactor Laps page to show driver leaderboard with expandable lap history

### DIFF
--- a/racemate-web/src/pages/Compare.tsx
+++ b/racemate-web/src/pages/Compare.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from "preact/hooks";
+import { useSearch } from "wouter";
 import { api } from "@/lib/api";
 import { CompareData, formatLapTime } from "@/lib/types";
 import { TrackMap } from "@/components/TrackMap";
@@ -8,6 +9,7 @@ const COLOR_A = "#e8304a";
 const COLOR_B = "#3b82f6";
 
 export function Compare() {
+  const search = useSearch();
   const [lapAId, setLapAId] = useState("");
   const [lapBId, setLapBId] = useState("");
   const [data, setData] = useState<CompareData | null>(null);
@@ -19,6 +21,21 @@ export function Compare() {
   const [speed, setSpeed] = useState(1);
   const rafRef = useRef<number | null>(null);
   const lastTimeRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    const params = new URLSearchParams(search);
+    const a = params.get("lap_a");
+    const b = params.get("lap_b");
+    if (!a || !b) return;
+    setLapAId(a);
+    setLapBId(b);
+    setLoading(true);
+    setError(null);
+    api.compare(a, b)
+      .then((d) => { setData(d); setCursor(0); setPlaying(false); })
+      .catch((e: unknown) => setError(e instanceof Error ? e.message : "Failed to load"))
+      .finally(() => setLoading(false));
+  }, [search]);
 
   useEffect(() => {
     if (!playing || !data) return;

--- a/racemate-web/src/pages/Laps.tsx
+++ b/racemate-web/src/pages/Laps.tsx
@@ -178,7 +178,11 @@ export function Laps() {
                       {/* Leaderboard row — one per driver */}
                       <tr
                         onClick={() => toggleExpand(entry.userId)}
-                        class={`border-t border-[var(--border)] cursor-pointer transition-colors ${entry.rank === 1 ? "border-t-0" : ""} ${
+                        onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); toggleExpand(entry.userId); } }}
+                        tabIndex={0}
+                        role="button"
+                        aria-expanded={isExpanded}
+                        class={`border-t border-[var(--border)] cursor-pointer transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-[var(--accent)] ${entry.rank === 1 ? "border-t-0" : ""} ${
                           isUser
                             ? "bg-[var(--accent)]/5 hover:bg-[var(--accent)]/10"
                             : "hover:bg-[var(--surface)]"
@@ -242,7 +246,11 @@ export function Laps() {
                           <tr
                             key={lap.id}
                             onClick={() => toggle(lap)}
-                            class={`border-t border-[var(--border)] cursor-pointer transition-colors ${
+                            onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); toggle(lap); } }}
+                            tabIndex={0}
+                            role="button"
+                            aria-label={`Lap ${lap.lap_number}, ${formatLapTime(lap.lap_time_ms)}`}
+                            class={`border-t border-[var(--border)] cursor-pointer transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-[var(--accent)] ${
                               sel ? "bg-[var(--surface)]" : "bg-[var(--bg)] hover:bg-[var(--surface)]"
                             }`}
                           >


### PR DESCRIPTION
## Summary
Transformed the Laps page from displaying individual laps in a flat list to a driver-focused leaderboard view with expandable lap history for each driver. This provides a clearer competitive overview while maintaining access to detailed lap data.

## Key Changes
- **Leaderboard structure**: Changed from flat lap list to grouped-by-driver view with ranking, best lap time, and delta to P1
- **Expandable driver rows**: Each driver row can be expanded to show all their laps for the selected track/class
- **Driver identification**: Added username display and "You" badge for the current authenticated user
- **Quick compare**: Added "vs P1 →" button for non-P1 drivers to quickly compare their best lap against the leader
- **Visual hierarchy**: 
  - Rank column with green highlighting for P1
  - Current user's rows highlighted with accent color
  - Sub-rows for individual laps with visual indentation
  - Expanded state indicator (rotating chevron)
- **State management**: Added `expandedDriver` state to track which driver's lap history is visible
- **Navigation integration**: Added `useLocation` hook to support direct navigation to compare view with pre-selected laps
- **Memoized leaderboard**: Used `useMemo` to efficiently compute driver rankings and deltas from sorted laps

## Implementation Details
- Introduced `DriverEntry` type to represent aggregated driver data (best lap, all laps, rank, delta to P1)
- Leaderboard computation groups laps by `user_id`, sorts by best lap time, and calculates rankings
- Expanded lap rows use smaller text and visual indentation to distinguish from main leaderboard rows
- Compare functionality automatically selects both laps and navigates to compare page
- Clearing selections when switching class/track to prevent stale comparisons

https://claude.ai/code/session_01Bd6MHqygD5WoYJ72cKyTGn