### PR TITLE
Downgrade Go version requirement to 1.25.8

### DIFF
--- a/racemate-api/go.mod
+++ b/racemate-api/go.mod
@@ -1,6 +1,6 @@
 module github.com/racemate/api
 
-go 1.26.1
+go 1.25.8
 
 require (
 	github.com/go-chi/chi/v5 v5.2.5


### PR DESCRIPTION
## Summary
Updated the Go version requirement in the module definition from 1.26.1 to 1.25.8.

## Changes
- Downgraded `go.mod` Go version from 1.26.1 to 1.25.8

## Details
This change reduces the minimum Go version required to build and run the racemate-api module, potentially improving compatibility with environments that have not yet upgraded to the latest Go release.

https://claude.ai/code/session_01B9CPQJdJG69n5yg8Vy2rTj