### PR TITLE
fix: use strip_prefix instead of manual prefix stripping

### DIFF
--- a/apxeer-desktop/src-tauri/src/results.rs
+++ b/apxeer-desktop/src-tauri/src/results.rs
@@ -425,8 +425,7 @@ fn parse_incident(node: &roxmltree::Node) -> Option<ParsedStreamEvent> {
     let with_pos = text[value_start..].find(with_marker)? + value_start + with_marker.len();
     let remainder = &text[with_pos..];
 
-    let detail = if remainder.starts_with("another vehicle ") {
-        let other_part = &remainder["another vehicle ".len()..];
+    let detail = if let Some(other_part) = remainder.strip_prefix("another vehicle ") {
         let other_name = other_part.rsplit_once('(')
             .map(|(name, _)| name.to_string())
             .unwrap_or_else(|| other_part.to_string());


### PR DESCRIPTION
Resolves clippy::manual_strip warning in results.rs by replacing the
starts_with + manual index slicing pattern with strip_prefix.

https://claude.ai/code/session_01Rurnju9kiD3mmRuZFZrrzf