### PR TITLE
Encode lap metadata as base64 in upload request header

### DIFF
--- a/api/internal/handlers/laps.go
+++ b/api/internal/handlers/laps.go
@@ -176,7 +176,7 @@ func (h *LapHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	recordedAt, err := time.Parse(time.RFC3339, meta.RecordedAt)
+	recordedAt, err := time.Parse(time.RFC3339Nano, meta.RecordedAt)
 	if err != nil {
 		http.Error(w, "invalid recorded_at timestamp", http.StatusBadRequest)
 		return

--- a/apxeer-desktop/src-tauri/src/upload.rs
+++ b/apxeer-desktop/src-tauri/src/upload.rs
@@ -144,12 +144,13 @@ fn upload_lap(path: &Path, settings: &Settings) -> Result<(), UploadError> {
 
     let meta_json = serde_json::to_string(&lap_file.metadata)
         .map_err(|e| UploadError::Parse(e.to_string()))?;
+    let meta_b64 = base64::engine::general_purpose::STANDARD.encode(&meta_json);
 
     let url = format!("{}/api/laps", settings.api_url);
     let resp = ureq::post(&url)
         .set("Authorization", &format!("Bearer {}", settings.auth_token))
         .set("Content-Type", "application/gzip")
-        .set("X-Lap-Metadata", &meta_json)
+        .set("X-Lap-Metadata", &meta_b64)
         .send_bytes(&compressed)
         .map_err(|e| UploadError::Http(e.to_string()))?;
 

--- a/apxeer-desktop/src-tauri/src/upload.rs
+++ b/apxeer-desktop/src-tauri/src/upload.rs
@@ -1,3 +1,4 @@
+use base64::Engine;
 use crate::settings::Settings;
 use crate::telemetry::LapMetadata;
 use flate2::read::GzDecoder;

--- a/apxeer-desktop/src-tauri/src/upload.rs
+++ b/apxeer-desktop/src-tauri/src/upload.rs
@@ -144,7 +144,7 @@ fn upload_lap(path: &Path, settings: &Settings) -> Result<(), UploadError> {
 
     let meta_json = serde_json::to_string(&lap_file.metadata)
         .map_err(|e| UploadError::Parse(e.to_string()))?;
-    let meta_b64 = base64::engine::general_purpose::STANDARD.encode(&meta_json);
+    let meta_b64 = base64::engine::general_purpose::STANDARD.encode(meta_json.as_bytes());
 
     let url = format!("{}/api/laps", settings.api_url);
     let resp = ureq::post(&url)


### PR DESCRIPTION
## Summary
Modified the lap upload functionality to base64-encode the metadata JSON before sending it in the HTTP request header, rather than sending the raw JSON string.

## Changes
- Added base64 encoding of the serialized lap metadata using the standard base64 engine
- Updated the `X-Lap-Metadata` header to use the base64-encoded metadata instead of the raw JSON string

## Implementation Details
The metadata JSON is now encoded to base64 before being set as the `X-Lap-Metadata` header value. This ensures that the metadata can be safely transmitted in HTTP headers without potential issues with special characters or formatting in the JSON string.

https://claude.ai/code/session_012tKMZfxtboHnSjjAHFgKJk