### PR TITLE
Add user-specific sessions view with finish status and car classes

### DIFF
--- a/api/internal/handlers/users.go
+++ b/api/internal/handlers/users.go
@@ -92,7 +92,14 @@ func (h *UserHandler) Sessions(w http.ResponseWriter, r *http.Request) {
 		       t.name AS track_name, t.length_m,
 		       sr.finish_pos, sr.class_pos, sr.best_lap_ms,
 		       sr.laps_completed, sr.finish_status,
-		       c.name AS car_name, c.class AS car_class
+		       c.name AS car_name, c.class AS car_class,
+		       ARRAY(
+		         SELECT DISTINCT c2.class
+		         FROM session_results sr2
+		         JOIN cars c2 ON c2.id = sr2.car_id
+		         WHERE sr2.session_id = s.id
+		         ORDER BY 1
+		       ) AS car_classes
 		FROM session_results sr
 		JOIN sessions s ON s.id = sr.session_id
 		JOIN tracks   t ON t.id = s.track_id
@@ -130,6 +137,7 @@ func (h *UserHandler) Sessions(w http.ResponseWriter, r *http.Request) {
 		DurationMin int       `json:"duration_min"`
 		Track       track     `json:"track"`
 		MyResult    myResult  `json:"my_result"`
+		CarClasses  []string  `json:"car_classes"`
 	}
 
 	result := []userSession{}
@@ -145,6 +153,7 @@ func (h *UserHandler) Sessions(w http.ResponseWriter, r *http.Request) {
 			&mr.FinishPos, &mr.ClassPos, &mr.BestLapMs,
 			&mr.LapsCompleted, &mr.FinishStatus,
 			&mr.CarName, &mr.CarClass,
+			&s.CarClasses,
 		); err != nil {
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 			return

--- a/apxeer-web/src/lib/types.ts
+++ b/apxeer-web/src/lib/types.ts
@@ -109,6 +109,7 @@ export interface UserResult {
 
 export interface UserSession extends Session {
   my_result: UserResult;
+  car_classes: string[];
 }
 
 // Lap comparison data returned by GET /api/compare

--- a/apxeer-web/src/pages/Sessions.tsx
+++ b/apxeer-web/src/pages/Sessions.tsx
@@ -1,18 +1,41 @@
 import { useState, useEffect } from "preact/hooks";
 import { Link } from "wouter";
 import { api } from "@/lib/api";
-import type { Session } from "@/lib/types";
+import { useAuth } from "@/lib/auth";
+import type { UserSession } from "@/lib/types";
+
+function finishLabel(s: UserSession): { text: string; cls: string } {
+  const status = s.my_result.finish_status?.toLowerCase() ?? "";
+  if (!status || status === "finished") {
+    const pos = s.my_result.finish_pos;
+    return {
+      text: `P${pos}`,
+      cls: pos === 1 ? "text-yellow-400 font-semibold" : "",
+    };
+  }
+  return { text: s.my_result.finish_status!, cls: "text-[var(--muted)]" };
+}
 
 export function Sessions() {
-  const [sessions, setSessions] = useState<Session[]>([]);
+  const { user, loading: authLoading } = useAuth();
+  const [sessions, setSessions] = useState<UserSession[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    api.sessions.list().then(setSessions).catch((e) => setError(e.message)).finally(() => setLoading(false));
-  }, []);
+    if (authLoading) return;
+    if (!user) {
+      setLoading(false);
+      return;
+    }
+    api.users.sessions(user.id)
+      .then(setSessions)
+      .catch((e) => setError(e.message))
+      .finally(() => setLoading(false));
+  }, [user, authLoading]);
 
-  if (loading) return <p class="text-[var(--muted)]">Loading...</p>;
+  if (authLoading || loading) return <p class="text-[var(--muted)]">Loading...</p>;
+  if (!user) return <p class="text-[var(--muted)]">Sign in to view your sessions.</p>;
   if (error) return <p class="text-red-500">{error}</p>;
   if (sessions.length === 0) return <p class="text-[var(--muted)]">No sessions uploaded yet.</p>;
 
@@ -25,35 +48,42 @@ export function Sessions() {
           <thead class="border-b border-[var(--border)] text-[var(--muted)]">
             <tr>
               <th class="text-left px-4 py-2.5 font-normal">Date</th>
-              <th class="text-left px-4 py-2.5 font-normal">Event</th>
               <th class="text-left px-4 py-2.5 font-normal">Track</th>
               <th class="text-left px-4 py-2.5 font-normal">Type</th>
+              <th class="text-left px-4 py-2.5 font-normal">Car Classes</th>
               <th class="text-right px-4 py-2.5 font-normal">Duration</th>
+              <th class="text-right px-4 py-2.5 font-normal">Finished</th>
             </tr>
           </thead>
           <tbody>
-            {sessions.map((s, i) => (
-              <tr
-                key={s.id}
-                class={`border-t border-[var(--border)] hover:bg-[var(--surface)] transition-colors ${i === 0 ? "border-t-0" : ""}`}
-              >
-                <td class="px-4 py-2.5 text-[var(--muted)] whitespace-nowrap">
-                  {new Date(s.started_at).toLocaleDateString()}
-                </td>
-                <td class="px-4 py-2.5">
-                  <Link href={`/sessions/${s.id}`} class="hover:text-[var(--accent)] transition-colors">
-                    {s.event_name || "—"}
-                  </Link>
-                </td>
-                <td class="px-4 py-2.5 text-[var(--muted)]">
-                  {s.track?.name ?? s.track_id}
-                </td>
-                <td class="px-4 py-2.5 text-[var(--muted)]">{s.session_type}</td>
-                <td class="px-4 py-2.5 text-right text-[var(--muted)]">
-                  {s.duration_min > 0 ? `${s.duration_min} min` : "—"}
-                </td>
-              </tr>
-            ))}
+            {sessions.map((s, i) => {
+              const finish = finishLabel(s);
+              return (
+                <tr
+                  key={s.id}
+                  class={`border-t border-[var(--border)] hover:bg-[var(--surface)] transition-colors ${i === 0 ? "border-t-0" : ""}`}
+                >
+                  <td class="px-4 py-2.5 text-[var(--muted)] whitespace-nowrap">
+                    {new Date(s.started_at).toLocaleDateString()}
+                  </td>
+                  <td class="px-4 py-2.5">
+                    <Link href={`/sessions/${s.id}`} class="hover:text-[var(--accent)] transition-colors">
+                      {s.track?.name ?? s.track_id}
+                    </Link>
+                  </td>
+                  <td class="px-4 py-2.5 text-[var(--muted)]">{s.session_type}</td>
+                  <td class="px-4 py-2.5 text-[var(--muted)]">
+                    {s.car_classes?.join(", ") || "—"}
+                  </td>
+                  <td class="px-4 py-2.5 text-right text-[var(--muted)]">
+                    {s.duration_min > 0 ? `${s.duration_min} min` : "—"}
+                  </td>
+                  <td class={`px-4 py-2.5 text-right ${finish.cls}`}>
+                    {finish.text}
+                  </td>
+                </tr>
+              );
+            })}
           </tbody>
         </table>
       </div>


### PR DESCRIPTION
## Summary
Updated the Sessions page to display user-specific session data with enhanced information including finish positions/status and all car classes that participated in each session.

## Key Changes
- **Authentication Integration**: Sessions page now requires user authentication and displays user-specific sessions via `api.users.sessions(user.id)` instead of a generic sessions list
- **Finish Status Display**: Added `finishLabel()` helper function that displays:
  - Position (P1, P2, etc.) for completed sessions, with special styling for 1st place
  - Finish status (DNF, DNS, etc.) for non-completed sessions
- **Enhanced Table Layout**: 
  - Removed "Event" column and replaced with "Car Classes" column
  - Added "Finished" column showing position or status
  - Reordered columns for better UX (Date, Track, Type, Car Classes, Duration, Finished)
- **Car Classes Aggregation**: Backend now queries and returns all unique car classes that participated in each session
- **Type Updates**: Changed `Session` type to `UserSession` which includes `my_result` (user's specific result) and `car_classes` array
- **Loading States**: Improved loading state handling to account for both authentication and data loading

## Implementation Details
- The backend SQL query now includes a subquery to aggregate all distinct car classes per session
- Frontend properly waits for auth state before fetching sessions to ensure user context is available
- Finish status styling uses muted color for non-finished states and highlights 1st place in yellow

https://claude.ai/code/session_01TPuStfyNHMjPcLLAYxJLDv