### PR TITLE
Fix lap upload upsert for tracks without layout info

### DIFF
--- a/api/internal/handlers/laps.go
+++ b/api/internal/handlers/laps.go
@@ -185,12 +185,13 @@ func (h *LapHandler) Create(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	pool := h.DB.Pool
 
-	// Upsert track
+	// Upsert track — targets the partial index tracks_name_null_layout
+	// (layout is not available from desktop telemetry, so we insert with layout = NULL).
 	var trackID uuid.UUID
 	if err := pool.QueryRow(ctx, `
 		INSERT INTO tracks (id, name, length_m)
 		VALUES (gen_random_uuid(), $1, 0)
-		ON CONFLICT (name) DO UPDATE SET name = EXCLUDED.name
+		ON CONFLICT (name) WHERE layout IS NULL DO UPDATE SET name = EXCLUDED.name
 		RETURNING id
 	`, meta.TrackName).Scan(&trackID); err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/api/migrations/003_tracks_null_layout_index.up.sql
+++ b/api/migrations/003_tracks_null_layout_index.up.sql
@@ -1,0 +1,13 @@
+-- 003: Partial unique index for tracks without a layout.
+--
+-- Migration 002 changed the tracks unique constraint from UNIQUE (name) to
+-- UNIQUE (name, layout). PostgreSQL treats NULL as distinct, so two rows with
+-- the same name and layout IS NULL would not conflict, and ON CONFLICT (name)
+-- no longer targets any constraint — causing lap uploads to fail with a 500.
+--
+-- This partial index lets the upsert in the lap upload handler use:
+--   ON CONFLICT (name) WHERE layout IS NULL DO UPDATE ...
+-- which correctly deduplicates desktop-recorded laps that carry no layout info.
+CREATE UNIQUE INDEX IF NOT EXISTS tracks_name_null_layout
+    ON public.tracks(name)
+    WHERE layout IS NULL;


### PR DESCRIPTION
## Summary
Fixes lap uploads failing with a 500 error when upserting tracks that have no layout information (desktop-recorded laps). The issue was introduced in migration 002, which changed the tracks unique constraint from `UNIQUE (name)` to `UNIQUE (name, layout)`. Since PostgreSQL treats NULL as distinct, the `ON CONFLICT (name)` clause no longer targeted any constraint.

## Changes
- **Migration 003**: Added a partial unique index `tracks_name_null_layout` on the `name` column where `layout IS NULL`. This allows the upsert operation to correctly target and deduplicate tracks without layout information.
- **Lap handler**: Updated the track upsert query to use `ON CONFLICT (name) WHERE layout IS NULL DO UPDATE ...`, which now correctly targets the partial index and prevents duplicate track entries for desktop telemetry data.

## Implementation Details
- The partial index is only applied to rows where `layout IS NULL`, so it doesn't interfere with tracks that have layout information (which are uniquely constrained by the `(name, layout)` composite index).
- Desktop telemetry doesn't provide layout information, so these laps are inserted with `layout = NULL` and now properly deduplicate against existing tracks with the same name and no layout.

https://claude.ai/code/session_01QCZhCtDunnVrpwkkCPHbi2